### PR TITLE
Adding only finding running pods and continue;

### DIFF
--- a/arcaflow_plugin_kill_pod.py
+++ b/arcaflow_plugin_kill_pod.py
@@ -36,7 +36,10 @@ def _find_pods(core_v1, label_selector, name_pattern, namespace_pattern):
     finished = False
     while not finished:
         pod_response: V1PodList = core_v1.list_pod_for_all_namespaces(
-            watch=False, label_selector=label_selector
+            watch=False,
+            label_selector=label_selector,
+            field_selector="status.phase=Running",
+            _continue=_continue
         )
         for pod in pod_response.items:
             pod: V1Pod

--- a/arcaflow_plugin_kill_pod.py
+++ b/arcaflow_plugin_kill_pod.py
@@ -310,8 +310,6 @@ def wait_for_pods(
                         )
                     )
 
-
-
                 time.sleep(cfg.backoff)
 
                 now_time = datetime.now()

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -72,16 +72,16 @@ class KillPodTest(unittest.TestCase):
                 )
             )
             pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None,
-                                                        namespace_pattern=re.compile("^default$"),
-                                                        name_pattern=re.compile(
-                                                        "^" + re.escape(pod.metadata.name) + "$"
-                                                            ))
+                                                    namespace_pattern=re.compile("^default$"),
+                                                    name_pattern=re.compile(
+                                                    "^" + re.escape(pod.metadata.name) + "$"
+                                                    ))
             print("pods " + str(pods))
             while len(pods) == 0:
                 pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),
-                                                            name_pattern=re.compile(
-                                                            "^" + re.escape(pod.metadata.name) + "$"
-                                                            ))
+                                                        name_pattern=re.compile(
+                                                        "^" + re.escape(pod.metadata.name) + "$"
+                                                        ))
                 print("pods " + str(pods))
 
             def remove_test_pod():

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -76,11 +76,13 @@ class KillPodTest(unittest.TestCase):
                     name_pattern=re.compile(
                         "^" + re.escape(pod.metadata.name) + "$"
                     ))
-            while len(pods) != 0:
-                pods = core_v1._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),
+            print("pods "+ str(pods))
+            while len(pods) == 0:
+                pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),
                     name_pattern=re.compile(
                             "^" + re.escape(pod.metadata.name) + "$"
                     ))
+                print("pods "+ str(pods))
 
             def remove_test_pod():
                 try:

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -72,17 +72,17 @@ class KillPodTest(unittest.TestCase):
                 )
             )
             pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None,
-                    namespace_pattern=re.compile("^default$"),
-                    name_pattern=re.compile(
-                        "^" + re.escape(pod.metadata.name) + "$"
-                    ))
-            print("pods "+ str(pods))
+                        namespace_pattern=re.compile("^default$"),
+                        name_pattern=re.compile(
+                            "^" + re.escape(pod.metadata.name) + "$"
+                        ))
+            print("pods " + str(pods))
             while len(pods) == 0:
                 pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),
                     name_pattern=re.compile(
                             "^" + re.escape(pod.metadata.name) + "$"
                     ))
-                print("pods "+ str(pods))
+                print("pods " + str(pods))
 
             def remove_test_pod():
                 try:

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -72,14 +72,14 @@ class KillPodTest(unittest.TestCase):
                 )
             )
             pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None,
-                            namespace_pattern=re.compile("^default$"),
-                            name_pattern=re.compile(
+                                namespace_pattern=re.compile("^default$"),
+                                name_pattern=re.compile(
                                 "^" + re.escape(pod.metadata.name) + "$"
                             ))
             print("pods " + str(pods))
             while len(pods) == 0:
                 pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),
-                    name_pattern=re.compile(
+                            name_pattern=re.compile(
                             "^" + re.escape(pod.metadata.name) + "$"
                     ))
                 print("pods " + str(pods))

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -72,16 +72,16 @@ class KillPodTest(unittest.TestCase):
                 )
             )
             pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None,
-                                namespace_pattern=re.compile("^default$"),
-                                name_pattern=re.compile(
-                                "^" + re.escape(pod.metadata.name) + "$"
-                            ))
+                                                        namespace_pattern=re.compile("^default$"),
+                                                        name_pattern=re.compile(
+                                                        "^" + re.escape(pod.metadata.name) + "$"
+                                                            ))
             print("pods " + str(pods))
             while len(pods) == 0:
                 pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),
-                            name_pattern=re.compile(
-                            "^" + re.escape(pod.metadata.name) + "$"
-                    ))
+                                                            name_pattern=re.compile(
+                                                            "^" + re.escape(pod.metadata.name) + "$"
+                                                            ))
                 print("pods " + str(pods))
 
             def remove_test_pod():

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -72,15 +72,15 @@ class KillPodTest(unittest.TestCase):
                 )
             )
             pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None,
-                                                    namespace_pattern=re.compile("^default$"),
-                                                    name_pattern=re.compile(
-                                                    "^" + re.escape(pod.metadata.name) + "$"
+                                                        namespace_pattern=re.compile("^default$"),
+                                                        name_pattern=re.compile(
+                                                          "^" + re.escape(pod.metadata.name) + "$"
                                                     ))
             print("pods " + str(pods))
             while len(pods) == 0:
                 pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),
-                                                        name_pattern=re.compile(
-                                                        "^" + re.escape(pod.metadata.name) + "$"
+                                                            name_pattern=re.compile(
+                                                                "^" + re.escape(pod.metadata.name) + "$"
                                                         ))
                 print("pods " + str(pods))
 

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -72,16 +72,18 @@ class KillPodTest(unittest.TestCase):
                 )
             )
             pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None,
-                                                        namespace_pattern=re.compile("^default$"),
-                                                        name_pattern=re.compile(
+                                                    namespace_pattern=re.compile("^default$"),
+                                                    name_pattern=re.compile(
                                                           "^" + re.escape(pod.metadata.name) + "$"
-                                                    ))
+                                                        )
+                                                    )
             print("pods " + str(pods))
             while len(pods) == 0:
                 pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),
                                                             name_pattern=re.compile(
                                                                 "^" + re.escape(pod.metadata.name) + "$"
-                                                        ))
+                                                            )
+                                                        )
                 print("pods " + str(pods))
 
             def remove_test_pod():

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -72,10 +72,10 @@ class KillPodTest(unittest.TestCase):
                 )
             )
             pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None,
-                        namespace_pattern=re.compile("^default$"),
-                        name_pattern=re.compile(
-                            "^" + re.escape(pod.metadata.name) + "$"
-                        ))
+                            namespace_pattern=re.compile("^default$"),
+                            name_pattern=re.compile(
+                                "^" + re.escape(pod.metadata.name) + "$"
+                            ))
             print("pods " + str(pods))
             while len(pods) == 0:
                 pods = arcaflow_plugin_kill_pod._find_pods(core_v1, None, namespace_pattern=re.compile("^default$"),


### PR DESCRIPTION
 tests running for 4.12 openshift with pod privileges

## Changes introduced with this PR

1. Want to only kill pods that are running in any namespace 
2. Properly using the continue parameter in get list of pods 
3. Adding pod privileges to tests (Used [this doc ](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)for reference)

## Fixes 

https://github.com/arcalot/arcaflow-plugin-kill-pod/issues/5
https://github.com/arcalot/arcaflow-plugin-kill-pod/issues/6

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).