### PR TITLE
Wait container none

### DIFF
--- a/arcaflow_plugin_kill_pod.py
+++ b/arcaflow_plugin_kill_pod.py
@@ -288,9 +288,12 @@ def wait_for_pods(
                 ready_pods = 0
                 for pod in pods:
                     ready = True
-                    for container in pod.status.container_statuses:
-                        if not container.ready:
-                            ready = False
+                    if pod.status: 
+                        for container in pod.status.container_statuses:
+                            if not container.ready:
+                                ready = False
+                    else: 
+                        ready = False
                     if ready:
                         ready_pods += 1
 


### PR DESCRIPTION
In prow on a rosa cluster I found that if there is no current pod status the wait_for_pods errors out. This will fix that 

Fixes: https://github.com/redhat-chaos/arcaflow-plugin-kill-pod/issues/26


```
2023-05-26 15:24:48,111 [INFO] Executing scenarios for iteration 0
2023-05-26 15:24:48,111 [INFO] connection set up
127.0.0.1 - - [26/May/2023 15:24:48] "GET / HTTP/1.1" 200 -
2023-05-26 15:24:48,113 [INFO] response RUN
2023-05-26 15:24:48,113 [INFO] scenario scenarios/openshift/etcd.yml
2023-05-26 15:24:49,504 [INFO] {
        "output_id": "success",
        "output_data": {
                "pods": {
                        "1685129088460180000": {
                                "namespace": "openshift-etcd",
                                "name": "etcd-ip-10-0-193-57.us-east-2.compute.internal"
                        }
                }
        }
}

2023-05-26 15:26:11,347 [INFO] {
        "output_id": "success",
        "output_data": {
                "pods": [
                        {
                                "namespace": "openshift-etcd",
                                "name": "etcd-ip-10-0-190-219.us-east-2.compute.internal"
                        },
                        {
                                "namespace": "openshift-etcd",
                                "name": "etcd-ip-10-0-193-57.us-east-2.compute.internal"
                        },
                        {
                                "namespace": "openshift-etcd",
                                "name": "etcd-ip-10-0-250-20.us-east-2.compute.internal"
                        }
                ]
        }
}

2023-05-26 15:26:11,349 [INFO] Waiting for the specified duration: 60
2023-05-26 15:27:11,355 [INFO] 
2023-05-26 15:27:11
```