### PR TITLE
added `krkn_pod_recovery_time` to the schema

### DIFF
--- a/arcaflow_plugin_kill_pod.py
+++ b/arcaflow_plugin_kill_pod.py
@@ -144,6 +144,14 @@ class KillPodConfig:
         },
     )
 
+    krkn_pod_recovery_time: int = field(
+        default=60,
+        metadata={
+            "name": "Recovery Time",
+            "description": "The Expected Recovery time fo the pod (used by Krkn to monitor the pod lifecycle)",
+        },
+    )
+
     backoff: int = field(
         default=1,
         metadata={

--- a/tests/test_arcaflow_plugin_kill_pod.py
+++ b/tests/test_arcaflow_plugin_kill_pod.py
@@ -17,7 +17,8 @@ class KillPodTest(unittest.TestCase):
     def test_serialization(self):
         plugin.test_object_serialization(
             arcaflow_plugin_kill_pod.KillPodConfig(
-                namespace_pattern=re.compile(".*"), name_pattern=re.compile(".*")
+                # added knkn_pod_recovery_time only for schema testing
+                namespace_pattern=re.compile(".*"), name_pattern=re.compile(".*"),krkn_pod_recovery_time=30
             ),
             self.fail,
         )


### PR DESCRIPTION
This parameter has no functional impact to the plugin itself and it's optional in the schema. The only purpose is to have this parameter available to the krkn built-in pod monitor.